### PR TITLE
.semver:minor Dockerfiles without node, kubernetes, helm and terrafor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,6 @@ Plus:
 * .NET Core (current and latest LTS)
 * Azure CLI
 * PowerShell Core (pwsh - latest stable)
-* Node (latest LTS) and nvm, Npm and Yarn
-* Google Chrome
-* kubectl
-* Helm CLI
-* Terraform CLI
 * Openjdk (latest LTS)
 * Docker CLI
 * docker-compose

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -30,55 +30,12 @@ RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb
     apt-get install -y azure-cli
 # pwsh:
 RUN apt-get install -y powershell
-# nvm/node/yarn:
-RUN curl -fSsL https://deb.nodesource.com/setup_12.x | bash
-RUN apt-get install -y nodejs
-RUN curl -fSso- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
-RUN [ "/bin/bash", "-c", "source $HOME/.nvm/nvm.sh && nvm i 12 && nvm i 13" ]
-RUN [ "/bin/bash", "-c", "source $HOME/.nvm/nvm.sh && nvm alias default 13" ]
-RUN curl -fsS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && apt-get -y --no-install-recommends install yarn
-# chrome:
-RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    gdebi --non-interactive google-chrome-stable_current_amd64.deb && \
-    rm google-chrome-stable_current_amd64.deb
-# kubectl:
-RUN curl -fSs https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
-    apt-get update && \
-    apt-get install -y kubectl
-# helm 2:
-RUN curl -fSsL https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash && \
-    mv /usr/local/bin/helm /usr/local/bin/helm2
-# helm 3:
-RUN curl -fSsL https://github.com/helm/helm/raw/master/scripts/get-helm-3 | bash
-# terraform:
-RUN wget -q https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_linux_amd64.zip -O terraform.zip && \
-    unzip -d /usr/local/bin/ terraform.zip && \
-    rm terraform.zip
 # openjdk
 RUN apt-get install -y default-jdk
-# mssql-cli
-# todo move to apt when https://github.com/dbcli/mssql-cli/issues/257 is fixed
-RUN wget -q https://packages.microsoft.com/ubuntu/17.10/prod/pool/main/m/mssql-cli/mssql-cli_0.15.0-1_all.deb -O mssql-cli.deb && \
-    dpkg -i mssql-cli.deb && \
-    rm mssql-cli.deb
-# sqlcmd
-RUN ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev locales && \
-    locale-gen en_US.UTF-8 && \
-    update-locale LANG=en_US.UTF-8
-ENV PATH="${PATH}:/opt/mssql-tools/bin/"
-# docker cli
-RUN curl -fSsL https://download.docker.com/linux/static/stable/x86_64/docker-19.03.5.tgz -o docker.tgz && \
-  tar xzvf docker.tgz --strip 1 -C /usr/local/bin docker/docker && \
-  rm docker.tgz
-RUN curl -fSsL https://github.com/docker/compose/releases/download/1.25.4/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose
 # cleanup
 RUN apt-get autoremove -y
 # agent:
-RUN curl -fSsL https://vstsagentpackage.azureedge.net/agent/2.164.7/vsts-agent-linux-x64-2.164.7.tar.gz -o /agent/vsts-agent.tar.gz && \
+RUN curl -fSsL https://vstsagentpackage.azureedge.net/agent/2.188.3/vsts-agent-linux-x64-2.188.3.tar.gz -o /agent/vsts-agent.tar.gz && \
     tar xzf /agent/vsts-agent.tar.gz && \
     rm /agent/vsts-agent.tar.gz
 COPY configureAgent.sh runAgent.sh configureAndRun.sh /agent/

--- a/agent/configureAgent.sh
+++ b/agent/configureAgent.sh
@@ -4,7 +4,7 @@ if [ "$DEBUG" == 'true' ]; then
   set -x
 fi
 set -eo pipefail
-if [ -z $AGENT_POOL ]; then AGENT_POOL=Default; fi
+if [ -z "$AGENT_POOL" ]; then AGENT_POOL=Default; fi
 if [ -z $VS_TENANT ]; then
   >&2 echo 'Variable "$VS_TENANT" is not set.'
   exit 1
@@ -23,7 +23,7 @@ if [ ! -f $DIR/.credentials ]; then
     sudo mkdir -p $work_dir
   fi
   sudo chown -R agentuser:agentuser $work_dir
-  $DIR/bin/Agent.Listener configure --url https://dev.azure.com/$vs_tenant --pool $agent_pool --auth PAT --token $agent_pat --agent $(hostname) --work $work_dir --unattended
+  $DIR/bin/Agent.Listener configure --url https://dev.azure.com/$vs_tenant --pool "$agent_pool" --auth PAT --token $agent_pat --agent $(hostname) --work $work_dir --unattended
   check $?
 fi
 unset AGENT_PAT


### PR DESCRIPTION
- removes node, kubernetes, helm, terraform and mssql-cli from the Dockerfile
- updates version of the user agent to 2.188.3
- fixes configureAgent.sh to support AGENT_POOL environment variable with spaces (eg Vienna Linux)